### PR TITLE
Make sidebar scrollable, adjust mobile sizing, and perf fix

### DIFF
--- a/jpgram/templates/base.html
+++ b/jpgram/templates/base.html
@@ -24,6 +24,24 @@
             color: var(--color-dark);
         }
 
+        .sidebar::-webkit-scrollbar {
+            width: 8px;
+        }
+
+        .sidebar::-webkit-scrollbar-track {
+            background: var(--color-medium);
+        }
+
+        .sidebar::-webkit-scrollbar-thumb {
+            background-color: var(--color-beige);
+            border-radius: 10px;
+            transition: background-color 0.3s ease;
+        }
+
+        .sidebar::-webkit-scrollbar-thumb:hover {
+            background-color: grey;
+        }
+
         .sidebar {
             position: fixed;
             top: 0;
@@ -32,8 +50,17 @@
             height: 100%;
             background-color: var(--color-medium);
             padding: 2rem;
+            padding-right: max(2rem, 50px);
+            overflow-y: auto;
+            overflow-x: hidden;
             transition: all 0.3s ease;
             z-index: 1;
+            direction: rtl;
+            will-change: transform;
+        }
+
+        .sidebar * {
+            direction: ltr;
         }
 
         .sidebar h3 {
@@ -66,64 +93,52 @@
 
         .sidebar.collapsed {
             transform: translateX(calc(-1 * (var(--sidebar-width) - var(--collapsed-width))));
-            padding-right: var(--collapsed-width);
         }
 
-        .sidebar.collapsed a {
-            color: var(--color-medium);
-            pointer-events: none;
+
+        #sidebar-toggle.collapsed {
+            left: var(--collapsed-width);
         }
 
-        .sidebar.collapsed #sidebar-toggle i {
+        #sidebar-toggle.collapsed i {
             transform: rotate(-180deg);
-        }
-
-        .main-content.collapsed {
-            padding-left: calc(var(--collapsed-width) + 2rem);
         }
 
         .t-big {
             font-size: 38px;
         }
 
-        h3.t-big {
-            margin-right: 50px;
-        }
-
         #sidebar-toggle {
-            background-color: transparent;
+            background-color: var(--color-medium);
             border: none;
             font-size: 24px;
-            position: absolute;
+            position: fixed;
             top: 2rem;
-            right: 0;
+            left: var(--sidebar-width);
             padding: 5px;
             display: flex;
             align-items: center;
             justify-content: center;
-            width: var(--collapsed-width);
-            height: var(--collapsed-width);
+            width: 50px;
+            height: 50px;
             color: var(--color-beige);
+            transition: all 0.3s ease;
+            z-index: 2;
+            transform: translateX(-100%);
         }
 
         #sidebar-toggle i {
             transition: all 0.3s ease;
-        }
-
-        #sidebar-toggle i {
             transform: rotate(0deg);
         }
-
 
         #sidebar-toggle:hover {
             background-color: rgb(53, 53, 53);
         }
 
-
         .main-content {
             padding: 2rem;
-            padding-left: calc(var(--sidebar-width) + 2rem);
-            transition: all 0.3s ease;
+            padding-left: calc(var(--collapsed-width) + 2rem);
             width: 100%;
         }
 
@@ -156,24 +171,19 @@
                 --collapsed-width: 0px;
             }
 
-            .main-content {
-                padding-left: calc(var(--collapsed-width) + 2rem);
-            }
-
             #sidebar-toggle {
                 width: 50px;
                 height: 50px;
                 background-color: var(--color-medium);
-                transition: transform 0.5s ease;
             }
 
             #sidebar-toggle:hover {
                 background-color: var(--color-medium);
             }
 
-            .sidebar.collapsed #sidebar-toggle {
-                transform: translateX(calc(50px + 2rem));
-                /* color: var(--color-medium); */
+            #sidebar-toggle.collapsed {
+                left: 2rem;
+                transform: translateX(0);
             }
         }
     </style>
@@ -183,10 +193,11 @@
 <body>
     <div class="container-fluid">
         <div class="row">
+            <button id="sidebar-toggle" class="btn btn-light">
+                <i class="fas fa-chevron-left"></i>
+            </button>
             <div class="col-md-3 col-lg-2 sidebar">
-                <button id="sidebar-toggle" class="btn btn-light">
-                    <i class="fas fa-chevron-left"></i>
-                </button>
+
 
                 <h3 class="text-center mb-4 t-big">College Hubs</h3>
                 <ul>
@@ -219,6 +230,7 @@
         document.getElementById('sidebar-toggle').addEventListener('click', function () {
             document.querySelector('.sidebar').classList.toggle('collapsed');
             document.querySelector('.main-content').classList.toggle('collapsed');
+            document.querySelector('#sidebar-toggle').classList.toggle('collapsed');
         });
     </script>
     {% block extra_js %}{% endblock %}

--- a/jpgram/templates/base.html
+++ b/jpgram/templates/base.html
@@ -16,7 +16,8 @@
             --color-light: #697565;
             --color-beige: #ECDFCC;
             --sidebar-width: 350px;
-            --collapsed-width: 50px;
+            --collapsed-width: var(--menubtn-size);
+            --menubtn-size: 50px;
         }
 
         body {
@@ -50,7 +51,7 @@
             height: 100%;
             background-color: var(--color-medium);
             padding: 2rem;
-            padding-right: max(2rem, 50px);
+            padding-right: max(2rem, var(--menubtn-size));
             overflow-y: auto;
             overflow-x: hidden;
             transition: all 0.3s ease;
@@ -119,8 +120,8 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            width: 50px;
-            height: 50px;
+            width: var(--menubtn-size);
+            height: var(--menubtn-size);
             color: var(--color-beige);
             transition: all 0.3s ease;
             z-index: 2;
@@ -169,11 +170,14 @@
             :root {
                 --sidebar-width: 80vw;
                 --collapsed-width: 0px;
+                --menubtn-size: 40px;
+            }
+
+            .t-big {
+                font-size: 28px;
             }
 
             #sidebar-toggle {
-                width: 50px;
-                height: 50px;
                 background-color: var(--color-medium);
             }
 


### PR DESCRIPTION
Fix #20 #21 

Commit 1:
Restructure menu btn.
Made sidebar scrollable.
Add scrollbar to left size according to theme.
Made sidebar as overlay to prevent content changing size on medium size screens, to fix performance.

Preview:
https://github.com/user-attachments/assets/ba73626f-1369-4995-b985-9276c01417df


Commit 2:
Made menu btn size easy to adjust
Adjust font size and menu btn size for better readbility on mobile
![image](https://github.com/user-attachments/assets/2c15e097-c2b0-49a6-9047-d3962970456e)
![image](https://github.com/user-attachments/assets/5a865688-4c21-47fa-a0e0-256f4e5d8197)
